### PR TITLE
Adds style configuration.

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -5,6 +5,9 @@ module.exports =
     yapfPath:
       type: 'string'
       default: 'yapf'
+    yapfStyle:
+      type: 'string'
+      default: ''
     formatOnSave:
       type: 'boolean'
       default: false

--- a/lib/python-yapf.coffee
+++ b/lib/python-yapf.coffee
@@ -71,8 +71,12 @@ class PythonYAPF
     if not @checkForPythonContext()
       return
 
-    params = [@getFilePath(), "-i"]
+    yapfStyle = atom.config.get('python-yapf.yapfStyle')
     yapfPath = atom.config.get('python-yapf.yapfPath')
+    params = [@getFilePath(), "-i"]
+    if yapfStyle.length
+      params = params.concat ["--style", yapfStyle]
+    alert("params = " + params)
     which = process.spawnSync('which', ['yapf']).status
     if which == 1 and not fs.existsSync(yapfPath)
       @updateStatusbarText("unable to open " + yapfPath, false)


### PR DESCRIPTION
I like to run yapf with a slightly modified style, specifically I use a `column_limit` of 120 instead of the PEP8 default of 80. With this PR I can set the yapf style via the package settings page. For example, `{based_on_style: pep8, column_limit: 120}`
