### PR TITLE
Fixes grammar and normalize path.

### DIFF
--- a/lib/python-yapf.coffee
+++ b/lib/python-yapf.coffee
@@ -1,4 +1,4 @@
-fs = require 'fs'
+fs = require 'fs-plus'
 $ = require 'jquery'
 process = require 'child_process'
 
@@ -9,7 +9,7 @@ class PythonYAPF
     editor = atom.workspace.getActiveTextEditor()
     if not editor?
       return false
-    return editor.getGrammar().name == 'Python' or editor.getGrammar().name == 'MagicPython'
+    return editor.getGrammar().scopeName == 'source.python'
 
   removeStatusbarItem: =>
     @statusBarTile?.destroy()
@@ -45,7 +45,7 @@ class PythonYAPF
       return
 
     updateStatusbarText = @updateStatusbarText
-    yapfPath = atom.config.get('python-yapf.yapfPath')
+    yapfPath = fs.normalize(atom.config.get('python-yapf.yapfPath'))
     yapfStyle = atom.config.get('python-yapf.yapfStyle')
 
     params = [@getFilePath(), "-d"]
@@ -77,7 +77,7 @@ class PythonYAPF
       return
 
     updateStatusbarText = @updateStatusbarText
-    yapfPath = atom.config.get('python-yapf.yapfPath')
+    yapfPath = fs.normalize(atom.config.get('python-yapf.yapfPath'))
     yapfStyle = atom.config.get('python-yapf.yapfStyle')
 
     proc_params = [@getFilePath(), "-i"]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
+    "fs-plus": "^2.8.1",
     "jquery": "^2"
   }
 }


### PR DESCRIPTION
- Checking `sourceName` equal to `source.python` should work for all Python-like grammars, such as `langauage-python` and `MagicPython` and any others.
- Normalizing the file path using Atom's own `fs-plus` package allows users to specify `~` in their paths.
