### PR TITLE
Indicate yapf is working with an hourglass symbol.

### DIFF
--- a/lib/python-yapf.coffee
+++ b/lib/python-yapf.coffee
@@ -77,6 +77,7 @@ class PythonYAPF
       return
 
     updateStatusbarText = @updateStatusbarText
+    updateStatusbarText('⧗', false)
     yapfPath = atom.config.get('python-yapf.yapfPath')
     yapfStyle = atom.config.get('python-yapf.yapfStyle')
 


### PR DESCRIPTION
For some code, yapf may take a long time to finish working. There's no indication that this is happening. I've added a black hourglass symbol to the statusbar indicator to represent yapf is currently processing.
