### PR TITLE
Allow relative paths by using "hasbin" to check for executable

### DIFF
--- a/lib/python-yapf.coffee
+++ b/lib/python-yapf.coffee
@@ -1,6 +1,7 @@
 fs = require 'fs-plus'
 $ = require 'jquery'
 process = require 'child_process'
+hasbin = require 'hasbin'
 
 module.exports =
 class PythonYAPF
@@ -35,7 +36,7 @@ class PythonYAPF
       return
 
     yapfPath = fs.normalize atom.config.get 'python-yapf.yapfPath'
-    if not fs.existsSync yapfPath
+    if not fs.existsSync(yapfPath) and not hasbin.sync(yapfPath)
       @updateStatusbarText 'unable to open ' + yapfPath, false
       return
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "hasbin": "^1",
     "atom-space-pen-views": "^2.2.0",
     "fs-plus": "^2.8.1",
     "jquery": "^2"


### PR DESCRIPTION
Hi

I use Virtual Environments a lot in python, and having atom use yapf from the active virtualenv can be done by just executing from PATH using relative paths.

I use hasbin node package to detect if the bin is accesible or not.
